### PR TITLE
hard coded cmake install path

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,26 +1,39 @@
 use cmake::Config;
+//use std::env;
+//use std::path::Path;
 
 fn main() {
+    // check OS and select cpp compiler
     #[cfg(not(target_family = "unix"))]
     compile_error!("this only supports unix systems");
-
     #[cfg(target_os = "macos")]
     let cpp_lib = "c++";
     #[cfg(not(target_os = "macos"))]
     let cpp_lib = "stdc++";
 
+    //let dir = env::var("OUT_DIR").unwrap();
+    //let dest_path = Path::new(&dir).join("hello.rs");
+
+    // set config for library
     let dst = Config::new(".")
         .define("COORDGEN_BUILD_TESTS", "OFF")
         .define("COORDGEN_BUILD_EXAMPLE", "OFF")
         .define("COORDGEN_BUILD_SHARED_LIBS", "OFF")
+        .define("COORDGEN_BUILD_DIR", "/lib")
         .define("CMAKE_BUILD_TYPE", "Release")
         .uses_cxx11()
         .build();
-
+    // creates link to lib
     println!(
         "cargo:rustc-link-search=native={}",
         dst.join("lib").display()
     );
+    // creates link to lib64
+    println!(
+        "cargo:rustc-link-search=native={}",
+        dst.join("lib64").display()
+    );
+
     println!("cargo:rustc-link-lib=static=coordgen");
     println!("cargo:rustc-link-lib=static=wrappedcoordgen");
     println!("cargo:rustc-link-lib={}", cpp_lib);

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,8 @@
 use cmake::Config;
-//use std::env;
-//use std::path::Path;
+
+fn out_dir(){
+    
+}
 
 fn main() {
     // check OS and select cpp compiler
@@ -11,29 +13,23 @@ fn main() {
     #[cfg(not(target_os = "macos"))]
     let cpp_lib = "stdc++";
 
-    //let dir = env::var("OUT_DIR").unwrap();
-    //let dest_path = Path::new(&dir).join("hello.rs");
-
-    // set config for library
     let dst = Config::new(".")
         .define("COORDGEN_BUILD_TESTS", "OFF")
         .define("COORDGEN_BUILD_EXAMPLE", "OFF")
         .define("COORDGEN_BUILD_SHARED_LIBS", "OFF")
-        .define("COORDGEN_BUILD_DIR", "/lib")
         .define("CMAKE_BUILD_TYPE", "Release")
         .uses_cxx11()
         .build();
-    // creates link to lib
+    // in either of two directories
     println!(
         "cargo:rustc-link-search=native={}",
         dst.join("lib").display()
     );
-    // creates link to lib64
     println!(
         "cargo:rustc-link-search=native={}",
         dst.join("lib64").display()
     );
-
+    //link libraries
     println!("cargo:rustc-link-lib=static=coordgen");
     println!("cargo:rustc-link-lib=static=wrappedcoordgen");
     println!("cargo:rustc-link-lib={}", cpp_lib);

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,5 @@
 use cmake::Config;
 
-fn out_dir(){
-    
-}
-
 fn main() {
     // check OS and select cpp compiler
     #[cfg(not(target_family = "unix"))]

--- a/wrapper/CMakeLists.txt
+++ b/wrapper/CMakeLists.txt
@@ -1,6 +1,5 @@
 project(wrappedcoordgen)
 set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_INSTALL_LIBDIR "/lib")
 add_library(wrappedcoordgen STATIC get_coordinates.cpp)
 target_link_libraries(wrappedcoordgen coordgen)
 

--- a/wrapper/CMakeLists.txt
+++ b/wrapper/CMakeLists.txt
@@ -1,5 +1,6 @@
 project(wrappedcoordgen)
 set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_INSTALL_LIBDIR "/lib")
 add_library(wrappedcoordgen STATIC get_coordinates.cpp)
 target_link_libraries(wrappedcoordgen coordgen)
 

--- a/wrapper/CMakeLists.txt
+++ b/wrapper/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(wrappedcoordgen)
 set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_INSTALL_LIBDIR "/lib")
+set(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_PREFIX}/lib")
 add_library(wrappedcoordgen STATIC get_coordinates.cpp)
 target_link_libraries(wrappedcoordgen coordgen)
 


### PR DESCRIPTION
Hard coded cmake install path by setting CMAKE_INSTALL_LIBDIR to /lib
Compared it to previous value and was /lib64 and corrected.